### PR TITLE
Reduce use of substr for readability/performance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Changed
 
 - The minimum PHP version requirement has been raised to 8.0.
+- The str_starts_with and str_ends_with functions have been used instead of substr where possible.
 
 ### Deprecated
 

--- a/src/VuFindCode/EAN.php
+++ b/src/VuFindCode/EAN.php
@@ -92,10 +92,8 @@ class EAN
     public static function isValidEAN13($ean)
     {
         $ean = static::normalizeEAN($ean);
-        if (strlen($ean) != 13) {
-            return false;
-        }
-        return
-            substr($ean, 12) == self::getEAN13CheckDigit(substr($ean, 0, 12));
+        return (strlen($ean) != 13)
+            ? false
+            : str_ends_with($ean, self::getEAN13CheckDigit(substr($ean, 0, 12)));
     }
 }

--- a/src/VuFindCode/ISBN.php
+++ b/src/VuFindCode/ISBN.php
@@ -84,7 +84,7 @@ class ISBN
                 return $this->raw;
             } elseif (
                 strlen($this->raw) == 13
-                && substr($this->raw, 0, 3) == '978'
+                && str_starts_with($this->raw, '978')
             ) {
                 // Is it a Bookland EAN?  If so, we can convert to ISBN-10.
                 $start = substr($this->raw, 3, 9);
@@ -176,10 +176,9 @@ class ISBN
     public static function isValidISBN10($isbn)
     {
         $isbn = self::normalizeISBN($isbn);
-        if (strlen($isbn) != 10) {
-            return false;
-        }
-        return substr($isbn, 9) == self::getISBN10CheckDigit(substr($isbn, 0, 9));
+        return (strlen($isbn) != 10)
+            ? false
+            : str_ends_with($isbn, self::getISBN10CheckDigit(substr($isbn, 0, 9)));
     }
 
     /**

--- a/src/VuFindCode/ISMN.php
+++ b/src/VuFindCode/ISMN.php
@@ -83,7 +83,7 @@ class ISMN
                 return $this->raw;
             } elseif (
                 strlen($this->raw) == 13
-                && substr($this->raw, 0, 3) == '979'
+                && str_starts_with($this->raw, '979')
             ) {
                 // Is it a music EAN?  If so, we can convert to ISMN-10.
                 $start = 'M' . substr($this->raw, 4, 8);


### PR DESCRIPTION
This PR is inspired by https://github.com/vufind-org/vufind/pull/3196 and simplifies code by using str_starts_with and str_ends_with instead of substr where feasible.